### PR TITLE
Ajusta integración de cuentas BCB en Gateway

### DIFF
--- a/src/common/common.controller.ts
+++ b/src/common/common.controller.ts
@@ -11,7 +11,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { MessagePattern, Payload } from '@nestjs/microservices';
-import { ApiBody, ApiConsumes, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiConsumes, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
 import { FileInterceptor } from '@nestjs/platform-express';
 import {
   WhatsappService,
@@ -183,7 +183,7 @@ export class CommonController {
         },
         eif: {
           type: 'string',
-          example: 'MLD10000',
+          example: 'MLD1014',
         },
         ciNitOriginante: {
           type: 'string',
@@ -245,7 +245,7 @@ export class CommonController {
   @ApiOperation({ summary: 'Crear cuenta BCB' })
   @ApiBody({
     description:
-      'Datos de la cuenta a registrar en BCB. eifCuenta es la cuenta de la Entidad Financiera; cta es la cuenta transitoria que devuelve BCB.',
+      'Datos de la cuenta a registrar en BCB. eifCuenta es la cuenta de la Entidad Financiera; cta no se envia en creacion, lo devuelve BCB como cuenta transitoria.',
     required: true,
     schema: {
       type: 'object',
@@ -253,22 +253,28 @@ export class CommonController {
       properties: {
         eif: {
           type: 'string',
+          description: 'Codigo del participante en el MLD de la Entidad Financiera.',
           example: 'MLD1014',
         },
         eifCuenta: {
           type: 'string',
+          description: 'Numero de cuenta de la Entidad Financiera.',
           example: '1505651746',
         },
         ciNitTitular: {
           type: 'string',
+          description: 'Numero de documento o NIT del titular de la cuenta.',
           example: '234578021',
         },
         nombreTitular: {
           type: 'string',
-          example: 'DGPRUEBAS',
+          description: 'Nombre o razon social del titular de la cuenta.',
+          example: 'NAMEPRUEBA',
         },
         estado: {
           type: 'string',
+          description: 'Estado de la cuenta.',
+          enum: ['ACTIVO', 'INACTIVO'],
           example: 'ACTIVO',
         },
       },
@@ -276,7 +282,7 @@ export class CommonController {
         eif: 'MLD1014',
         eifCuenta: '1505651746',
         ciNitTitular: '234578021',
-        nombreTitular: 'DGPRUEBAS',
+        nombreTitular: 'NAMEPRUEBA',
         estado: 'ACTIVO',
       },
     },
@@ -291,17 +297,51 @@ export class CommonController {
 
   @Put('bcb.accounts/:cta')
   @ApiOperation({ summary: 'Actualizar cuenta BCB' })
+  @ApiParam({
+    name: 'cta',
+    required: true,
+    description: 'Cuenta transitoria devuelta por BCB al crear la cuenta.',
+    example: '130008101400006',
+  })
   @ApiBody({
-    description: 'Datos de la cuenta a actualizar en BCB',
+    description:
+      'Datos de la cuenta a actualizar en BCB. cta va en la URL; no debe enviarse en el body.',
     required: true,
     schema: {
       type: 'object',
-      additionalProperties: true,
+      properties: {
+        eif: {
+          type: 'string',
+          description: 'Codigo del participante en el MLD de la Entidad Financiera.',
+          example: 'MLD1014',
+        },
+        eifCuenta: {
+          type: 'string',
+          description: 'Numero de cuenta de la Entidad Financiera.',
+          example: '1505651746',
+        },
+        ciNitTitular: {
+          type: 'string',
+          description: 'Numero de documento o NIT del titular de la cuenta.',
+          example: '234578021',
+        },
+        nombreTitular: {
+          type: 'string',
+          description: 'Nombre o razon social del titular de la cuenta.',
+          example: 'NAMEPRUEBA EDITADO',
+        },
+        estado: {
+          type: 'string',
+          description: 'Estado de la cuenta.',
+          enum: ['ACTIVO', 'INACTIVO'],
+          example: 'ACTIVO',
+        },
+      },
       example: {
         eif: 'MLD1014',
         eifCuenta: '1505651746',
-        ciNitTitular: '1001543025',
-        nombreTitular: 'Percy',
+        ciNitTitular: '234578021',
+        nombreTitular: 'NAMEPRUEBA EDITADO',
         estado: 'ACTIVO',
       },
     },

--- a/src/common/common.controller.ts
+++ b/src/common/common.controller.ts
@@ -2,7 +2,9 @@ import {
   Controller,
   Get,
   HttpException,
+  Param,
   Post,
+  Put,
   UploadedFile,
   UseInterceptors,
   Body,
@@ -144,6 +146,26 @@ export class CommonController {
     }
   }
 
+  @MessagePattern('bcb.createAccount')
+  async createBcbAccount(@Payload() data: any) {
+    try {
+      return await this.bcbService.createAccount(data);
+    } catch (error) {
+      return this.buildBcbErrorResponse(error);
+    }
+  }
+
+  @MessagePattern('bcb.updateAccount')
+  async updateBcbAccount(@Payload() data: any) {
+    try {
+      const cta = data?.cta ?? data?.cuenta ?? data?.accountNumber;
+      const payload = data?.data ?? data;
+      return await this.bcbService.updateAccount(cta, payload);
+    } catch (error) {
+      return this.buildBcbErrorResponse(error);
+    }
+  }
+
   @ApiOperation({ summary: 'Recibir notificación BCB' })
   @ApiBody({
     description: 'Datos de respuesta del QR procesado',
@@ -217,6 +239,79 @@ export class CommonController {
   @ApiOperation({ summary: 'Obtener datos de entidad BCB' })
   async entities() {
     return await this.bcbService.entities();
+  }
+
+  @Post('bcb.accounts')
+  @ApiOperation({ summary: 'Crear cuenta BCB' })
+  @ApiBody({
+    description:
+      'Datos de la cuenta a registrar en BCB. eifCuenta es la cuenta de la Entidad Financiera; cta es la cuenta transitoria que devuelve BCB.',
+    required: true,
+    schema: {
+      type: 'object',
+      required: ['eif', 'eifCuenta', 'ciNitTitular', 'nombreTitular'],
+      properties: {
+        eif: {
+          type: 'string',
+          example: 'MLD1014',
+        },
+        eifCuenta: {
+          type: 'string',
+          example: '1505651746',
+        },
+        ciNitTitular: {
+          type: 'string',
+          example: '234578021',
+        },
+        nombreTitular: {
+          type: 'string',
+          example: 'DGPRUEBAS',
+        },
+        estado: {
+          type: 'string',
+          example: 'ACTIVO',
+        },
+      },
+      example: {
+        eif: 'MLD1014',
+        eifCuenta: '1505651746',
+        ciNitTitular: '234578021',
+        nombreTitular: 'DGPRUEBAS',
+        estado: 'ACTIVO',
+      },
+    },
+  })
+  async createAccount(@Body() data: any) {
+    try {
+      return await this.bcbService.createAccount(data);
+    } catch (error) {
+      return this.buildBcbErrorResponse(error);
+    }
+  }
+
+  @Put('bcb.accounts/:cta')
+  @ApiOperation({ summary: 'Actualizar cuenta BCB' })
+  @ApiBody({
+    description: 'Datos de la cuenta a actualizar en BCB',
+    required: true,
+    schema: {
+      type: 'object',
+      additionalProperties: true,
+      example: {
+        eif: 'MLD1014',
+        eifCuenta: '1505651746',
+        ciNitTitular: '1001543025',
+        nombreTitular: 'Percy',
+        estado: 'ACTIVO',
+      },
+    },
+  })
+  async updateAccount(@Param('cta') cta: string, @Body() data: any) {
+    try {
+      return await this.bcbService.updateAccount(cta, data);
+    } catch (error) {
+      return this.buildBcbErrorResponse(error);
+    }
   }
 
   @Get('bcb.status')

--- a/src/common/services/bcb.service.ts
+++ b/src/common/services/bcb.service.ts
@@ -101,6 +101,34 @@ export class BcbService {
     };
   }
 
+  async createAccount(data: any) {
+    const payload = this.normalizeCreateAccountPayload(data);
+    const response = await this.send('POST', 'v1/cuentas', payload);
+
+    this.validateFinalizedResponse(response);
+
+    return {
+      ...response,
+      serviceStatus: true,
+    };
+  }
+
+  async updateAccount(cta: string, data: any) {
+    if (!cta) {
+      throw new BadRequestException('La cuenta cta es obligatoria');
+    }
+
+    const payload = this.normalizeAccountPayload(data);
+    const response = await this.send('PUT', `v1/cuentas/${encodeURIComponent(cta)}`, payload);
+
+    this.validateFinalizedResponse(response);
+
+    return {
+      ...response,
+      serviceStatus: true,
+    };
+  }
+
   async send(method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE', endpoint: string, data?: any) {
     try {
       this.validateConfig();
@@ -262,6 +290,61 @@ export class BcbService {
     }
   }
 
+  private normalizeCreateAccountPayload(data: any) {
+    const payload = this.normalizeAccountPayload(data, true);
+    const missingFields = ['eif', 'eifCuenta', 'ciNitTitular', 'nombreTitular'].filter((field) =>
+      this.isBlank(payload[field]),
+    );
+
+    if (missingFields.length > 0) {
+      throw new BadRequestException({
+        finalizado: false,
+        mensaje: 'Datos de cuenta BCB inválidos',
+        errores: missingFields.map((field) => `${field}: es obligatorio`),
+      });
+    }
+
+    return payload;
+  }
+
+  private normalizeAccountPayload(data: any, useCreateAliases = false) {
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+      throw new BadRequestException({
+        finalizado: false,
+        mensaje: 'Datos de cuenta BCB inválidos',
+        errores: ['body: debe ser un objeto JSON'],
+      });
+    }
+
+    const payload = { ...data };
+    const eifCuenta = this.firstNonBlank(
+      data.eifCuenta,
+      data.eif_cuenta,
+      data.accountNumber,
+      useCreateAliases ? data.cta : undefined,
+      useCreateAliases ? data.cuenta : undefined,
+    );
+
+    if (eifCuenta !== undefined) {
+      payload.eifCuenta = String(eifCuenta);
+    }
+
+    delete payload.eif_cuenta;
+    delete payload.accountNumber;
+    delete payload.cta;
+    delete payload.cuenta;
+
+    return payload;
+  }
+
+  private firstNonBlank(...values: any[]) {
+    return values.find((value) => !this.isBlank(value));
+  }
+
+  private isBlank(value: any) {
+    return value === undefined || value === null || String(value).trim() === '';
+  }
+
   private buildUrl(path: string) {
     const baseUrl = this.bcbUrl.replace(/\/+$/, '');
     return path === '/' ? `${baseUrl}/` : `${baseUrl}${path}`;
@@ -275,6 +358,12 @@ export class BcbService {
   private validateFinalizedResponse(response: any) {
     if (response && typeof response === 'object' && response.finalizado === false) {
       throw new HttpException(response, HttpStatus.BAD_GATEWAY);
+    }
+
+    const message = typeof response?.mensaje === 'string' ? response.mensaje.toLowerCase() : '';
+
+    if (message.includes('no autorizado')) {
+      throw new HttpException(response, HttpStatus.FORBIDDEN);
     }
   }
 


### PR DESCRIPTION
Se normaliza `eifCuenta` para crear y actualizar cuentas BCB, evitando enviar alias internos a OpenBCB. También se maneja la respuesta “No autorizado para operar con esta entidad” como error `403`. Finalmente, se actualizan los ejemplos Swagger para reflejar correctamente el contrato de creación y edición de cuentas.