### PR TITLE
Refactoriza el webhook de notificaciones QR del BCB

### DIFF
--- a/src/common/common.controller.ts
+++ b/src/common/common.controller.ts
@@ -1,18 +1,16 @@
 import {
   Controller,
   Get,
-  Headers,
   Param,
   Post,
   Put,
-  Req,
   UploadedFile,
   UseInterceptors,
   Body,
   UseGuards,
 } from '@nestjs/common';
 import { MessagePattern, Payload } from '@nestjs/microservices';
-import { ApiBody, ApiConsumes, ApiHeader, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiConsumes, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
 import { FileInterceptor } from '@nestjs/platform-express';
 import {
   WhatsappService,
@@ -20,12 +18,10 @@ import {
   FtpService,
   CitizenshipDigitalService,
   BcbService,
-  BcbPaymentNotificationDto,
   SmsDto,
   WhatsappDto,
 } from 'src/common';
 import { AuthGuard } from 'src/auth/guards';
-import { Request } from 'express';
 
 @ApiTags('common')
 @Controller('common')
@@ -180,103 +176,6 @@ export class CommonController {
       return await this.bcbService.updateAccount(cta, payload);
     } catch (error) {
       return this.bcbService.buildErrorResponse(error);
-    }
-  }
-
-  @ApiOperation({ summary: 'Recibir notificación BCB' })
-  @ApiBody({
-    description: 'Datos de respuesta del QR procesado',
-    required: true,
-    schema: {
-      type: 'object',
-      properties: {
-        idQR: {
-          type: 'string',
-          example: '10000121715970417000',
-        },
-        idOrdenDestinatario: {
-          type: 'string',
-          example: '145266734545645630',
-        },
-        eif: {
-          type: 'string',
-          example: 'MLD1014',
-        },
-        ciNitOriginante: {
-          type: 'string',
-          example: '12345678',
-        },
-        nombreOriginante: {
-          type: 'string',
-          example: 'Juan Perez',
-        },
-        codMoneda: {
-          type: 'string',
-          example: 'BOB',
-        },
-        importe: {
-          type: 'number',
-          example: 20000,
-        },
-        cuentaOrigen: {
-          type: 'string',
-          example: '233333444',
-        },
-        eifOrigen: {
-          type: 'string',
-          example: 'MLD1014',
-        },
-        tipoNotificacion: {
-          type: 'string',
-          example: 'T1',
-        },
-        estado: {
-          type: 'string',
-          enum: ['PROCESADO', 'RECHAZADO', 'NO PROCESADO'],
-          example: 'PROCESADO',
-        },
-        metaData: {
-          type: 'object',
-          example: {
-            origen: 'sales-service',
-            schema: 'sales',
-            message: 'bcbPaymentNotification',
-            tipo: 'venta-qr',
-            personId: '123',
-          },
-          additionalProperties: true,
-        },
-      },
-      required: ['idQR', 'eif', 'codMoneda', 'estado', 'metaData'],
-    },
-  })
-  @ApiHeader({
-    name: 'Authorization',
-    required: false,
-    description: 'Validación Bearer temporalmente desactivada',
-  })
-  @Post('pagos/notificacion/notificacionPago')
-  async paymentNotification(
-    @Body() data: BcbPaymentNotificationDto,
-    @Headers('authorization') authorization: string | undefined,
-    @Req() request: Request,
-  ) {
-    this.bcbService.validateNotificationAccess(
-      authorization,
-      request.socket.remoteAddress,
-    );
-
-    try {
-      return await this.bcbService.processPaymentNotification(data);
-    } catch (error) {
-      const response = this.bcbService.buildErrorResponse(error);
-      const data = response.data;
-
-      return {
-        error: true,
-        message: response.message,
-        data,
-      };
     }
   }
 

--- a/src/common/notifications.controller.ts
+++ b/src/common/notifications.controller.ts
@@ -1,23 +1,13 @@
-import {
-  Controller,
-  Post,
-  Body,
-  UseGuards,
-} from '@nestjs/common';
-import { MessagePattern, Payload } from '@nestjs/microservices';
-import { ApiBody, ApiConsumes, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
 
-import { NatsService, BcbService } from 'src/common';
+import { BcbPaymentNotificationDto, BcbService } from 'src/common';
 import { AuthBcbGuard } from 'src/auth/guards';
 
 @ApiTags('notifications')
 @Controller('notifications')
 export class NotificationsController {
-
-  constructor(
-    private readonly nats: NatsService,
-    private readonly bcbService: BcbService,
-  ) {}
+  constructor(private readonly bcbService: BcbService) {}
 
   @ApiOperation({ summary: 'Recibir notificación BCB' })
   @ApiBody({
@@ -74,20 +64,22 @@ export class NotificationsController {
         metaData: {
           type: 'object',
           example: {
-            key: 'value',
+            origen: 'sales-service',
             schema: 'sales',
-            message: 'afterPayment',
+            message: 'bcbPaymentNotification',
+            tipo: 'venta-qr',
+            personId: '123',
           },
           additionalProperties: true,
         },
       },
-      required: ['idQR', 'eif', 'codMoneda', 'estado'],
+      required: ['idQR', 'eif', 'codMoneda', 'estado', 'metaData'],
     },
   })
+  @ApiBearerAuth('msp')
   @UseGuards(AuthBcbGuard)
   @Post('paymentQr')
-  async paymentNotification(@Body() body: any) {
-    return await this.nats.firstValue('sales.generateQr', body);
+  async paymentNotification(@Body() data: BcbPaymentNotificationDto) {
+    return await this.bcbService.processPaymentNotification(data);
   }
-
 }

--- a/src/common/services/bcb.service.ts
+++ b/src/common/services/bcb.service.ts
@@ -1,11 +1,8 @@
 import {
   BadRequestException,
-  ForbiddenException,
   HttpException,
   HttpStatus,
   Injectable,
-  ServiceUnavailableException,
-  UnauthorizedException,
 } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
@@ -27,15 +24,9 @@ export class BcbService {
   private readonly bcbKeyId = bcbEnvs.bcbKeyId;
   private readonly bcbSecret = bcbEnvs.bcbSecret;
   private readonly bcbToken = bcbEnvs.bcbToken;
-  private readonly bcbNotificationSecurityEnabled = false;
-  private readonly bcbNotificationToken = '[ENCRYPTION_KEY]';
-  private readonly bcbNotificationAllowedIps = ['[IP_ADDRESS]'];
   private readonly bcbRequestRetries = 2;
   private readonly bcbRetryDelayMs = 500;
   private readonly validQrStatuses: string[] = Object.values(BcbQrStatus);
-  private readonly allowedNotificationPatterns = new Set([
-    'sales.bcbPaymentNotification',
-  ]);
   private readonly unavailableMessage =
     'Servicio BCB fuera de servicio temporalmente. Intente nuevamente más tarde.';
 
@@ -118,61 +109,9 @@ export class BcbService {
     };
   }
 
-  validateNotificationAccess(authorization?: string, remoteAddress?: string): void {
-    if (!this.bcbNotificationSecurityEnabled) {
-      return;
-    }
-
-    const expectedToken = String(this.bcbNotificationToken ?? '').trim();
-
-    if (!expectedToken) {
-      throw new ServiceUnavailableException(
-        {
-          error: true,
-          message:
-            'BCB_NOTIFICATION_TOKEN no está configurado para proteger el webhook.',
-          data: null,
-        },
-      );
-    }
-
-    const [scheme, receivedToken] = String(authorization ?? '').trim().split(/\s+/, 2);
-
-    if (
-      scheme?.toLowerCase() !== 'bearer' ||
-      !receivedToken ||
-      !this.secureEquals(receivedToken, expectedToken)
-    ) {
-      throw new UnauthorizedException({
-        error: true,
-        message: 'Token de notificación BCB inválido.',
-        data: null,
-      });
-    }
-
-    const allowedIps = this.bcbNotificationAllowedIps
-      .map((ip) => this.normalizeIpAddress(ip))
-      .filter(Boolean);
-
-    if (allowedIps.length === 0) {
-      return;
-    }
-
-    const sourceIp = this.normalizeIpAddress(remoteAddress);
-
-    if (!sourceIp || !allowedIps.includes(sourceIp)) {
-      throw new ForbiddenException({
-        error: true,
-        message: 'IP de notificación BCB no autorizada.',
-        data: null,
-      });
-    }
-  }
-
   async processPaymentNotification(payload: BcbPaymentNotificationDto) {
     const bcbValidation = await this.notifications(payload);
-    const notificationPattern = this.resolveNotificationPattern(payload.metaData);
-    const salesResult = await this.nats.firstValue(notificationPattern, {
+    const salesResult = await this.nats.firstValue('sales.bcbPaymentNotification', {
       notification: payload,
       bcbValidation,
     });
@@ -526,44 +465,6 @@ export class BcbService {
     return errors;
   }
 
-  private resolveNotificationPattern(
-    metadata: Record<string, unknown>,
-  ): string {
-    const origin = String(metadata?.origen ?? '').trim();
-    const type = String(metadata?.tipo ?? '').trim();
-    const schema = String(metadata?.schema ?? '').trim();
-    const message = String(metadata?.message ?? '').trim();
-    const validSegment = /^[a-z][a-zA-Z0-9]*$/;
-
-    if (origin !== 'sales-service' || type !== 'venta-qr') {
-      throw new BadRequestException({
-        error: true,
-        message: 'Metadata BCB inválida para una venta QR.',
-        data: null,
-      });
-    }
-
-    if (!validSegment.test(schema) || !validSegment.test(message)) {
-      throw new BadRequestException({
-        error: true,
-        message: 'La ruta NATS indicada en metadata BCB no es válida.',
-        data: null,
-      });
-    }
-
-    const pattern = `${schema}.${message}`;
-
-    if (!this.allowedNotificationPatterns.has(pattern)) {
-      throw new BadRequestException({
-        error: true,
-        message: 'La ruta NATS indicada en metadata BCB no está autorizada.',
-        data: null,
-      });
-    }
-
-    return pattern;
-  }
-
   private throwBcbHttpError(error: any): never {
     if (error instanceof HttpException) {
       const status = error.getStatus();
@@ -674,19 +575,6 @@ export class BcbService {
     }
 
     return cleaned || this.unavailableMessage;
-  }
-
-  private secureEquals(receivedValue: string, expectedValue: string): boolean {
-    const received = Buffer.from(receivedValue, 'utf8');
-    const expected = Buffer.from(expectedValue, 'utf8');
-
-    return received.length === expected.length && crypto.timingSafeEqual(received, expected);
-  }
-
-  private normalizeIpAddress(value?: string): string {
-    return String(value ?? '')
-      .trim()
-      .replace(/^::ffff:/, '');
   }
 
   private async requestWithRetry<T>(request: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
## Descripción

Se centraliza el procesamiento de notificaciones de pago QR del BCB en el nuevo endpoint:

`POST /api/notifications/paymentQr`

## Cambios realizados

- Se implementó `NotificationsController` como punto único de entrada para las notificaciones BCB.
- Se agregó protección mediante `AuthBcbGuard` y JWT generado por `Auth-Service`.
- Se tipó el payload con `BcbPaymentNotificationDto`.
- Se corrigió el flujo para llamar a `BcbService.processPaymentNotification`.
- Se eliminó el endpoint duplicado `pagos/notificacion/notificacionPago` de `CommonController`.
- Se eliminó la validación redundante mediante token fijo e IP.
- Se eliminó el enrutamiento NATS dinámico basado en `metaData`.
- Las notificaciones ahora se envían directamente a `sales.bcbPaymentNotification`.
- Se actualizaron los ejemplos de Swagger con la metadata correcta.
- Se mantiene temporalmente el endpoint de generación del JWT para realizar pruebas con BCB.

## Flujo resultante

BCB → `AuthBcbGuard` → `NotificationsController` → `BcbService` → `sales.bcbPaymentNotification` → creación de la venta.

## Validaciones

- Compilación exitosa de Gateway Service.
- Validación de ESLint exitosa.
- Verificación de que no quedan referencias ejecutables al endpoint anterior ni al enrutamiento dinámico.